### PR TITLE
fix: calculate AF separately

### DIFF
--- a/workflow/rules/mtb_typing.smk
+++ b/workflow/rules/mtb_typing.smk
@@ -104,36 +104,6 @@ gatk CollectAllelicCounts \
 2>&1>{log}
         """
 
-rule mtb_ab_positions:
-    input:
-        bam=OUT + "/mtb_typing/prepared_files/{sample}.bam",
-        bai=OUT + "/mtb_typing/prepared_files/{sample}.bam.bai",
-        reference=OUT + "/mtb_typing/prepared_files/{sample}_ref.fasta",
-        dummy=OUT + "/mtb_typing/prepared_files/{sample}_ref.dict",
-        fai=OUT + "/mtb_typing/prepared_files/{sample}_ref.fasta.fai",
-        bed=lambda wildcards: SAMPLES[wildcards.sample]["ab_positions_bed"],
-    output:
-        tsv=OUT + "/mtb_typing/ab_positions/{sample}.tsv",
-    conda:
-        "../envs/gatk_picard.yaml"
-    container:
-        "docker://broadinstitute/gatk:4.3.0.0"
-    log:
-        OUT + "/log/mtb_typing/ab_positions/{sample}.log",
-    message:
-        "Assessing ab positions for {wildcards.sample}"
-    threads: config["threads"]["gatk"]
-    resources:
-        mem_gb=config["mem_gb"]["gatk"],
-    shell:
-        """
-gatk CollectAllelicCounts \
--I {input.bam} \
--R {input.reference} \
--L {input.bed} \
--O {output.tsv} \
-2>&1>{log}
-        """
 
 rule mtb_ab_positions:
     input:
@@ -273,7 +243,7 @@ gatk VariantsToTable \
 -F ALT \
 -F DP \
 -F FILTER \
--GF AF \
+-GF AD \
 -F {params.effect_column} \
 -O {output.tsv} 2>&1>{log}
         """
@@ -401,6 +371,7 @@ else
 fi
         """
 
+
 rule mtb_annotate_deletions:
     input:
         bed=OUT + "/mtb_typing/annotated_deletions/raw/{sample}.tsv",
@@ -433,58 +404,6 @@ else
     2>&1>{log}
 fi
         """
-
-# rule mtb_deletions_to_table:
-#     input:
-#         vcf=OUT + "/mtb_typing/prepared_files/deletions/{sample}.vcf",
-#     output:
-#         OUT + "/mtb_typing/annotated_deletions/raw/{sample}.tsv",
-#     conda:
-#         "../envs/gatk_picard.yaml"
-#     container:
-#         "docker://broadinstitute/gatk:4.3.0.0"
-#     log:
-#         OUT + "/log/mtb_deletions_to_table/{sample}.log",
-#     message:
-#         "Convert deletion vcf to table for {wildcards.sample}"
-#     threads: config["threads"]["gatk"]
-#     resources:
-#         mem_gb=config["mem_gb"]["gatk"],
-#     shell:
-#         """
-# gatk VariantsToTable \
-# -V {input.vcf} \
-# --show-filtered \
-# -F CHROM \
-# -F POS \
-# -F END \
-# -O {output} 2>&1>{log}
-#         """
-
-
-# rule mtb_annotate_deletions:
-#     input:
-#         bed=OUT + "/mtb_typing/annotated_deletions/raw/{sample}.tsv",
-#         resistance_deletions_bed=lambda wildcards: SAMPLES[wildcards.sample][
-#             "resistance_deletions_bed"
-#         ],
-#     output:
-#         tsv=OUT + "/mtb_typing/annotated_deletions/{sample}.tsv",
-#     log:
-#         OUT + "/log/mtb_annotate_deletions/{sample}.log",
-#     message:
-#         "Annotating deletions with AMR for {wildcards.sample}"
-#     threads: config["threads"]["other"]
-#     resources:
-#         mem_gb=config["mem_gb"]["other"],
-#     shell:
-#         """
-# python workflow/scripts/postprocess_deletion_table.py \
-# --input {input.bed} \
-# --bed {input.resistance_deletions_bed} \
-# --output {output} \
-# 2>&1>{log}
-#         """
 
 
 # rule mtb_deletions_to_table:

--- a/workflow/scripts/postprocess_variant_table.py
+++ b/workflow/scripts/postprocess_variant_table.py
@@ -100,13 +100,43 @@ def rename_columns(df, rename_dict):
         Renamed dataframe
     """
     df = df.rename(columns=rename_dict)
-    # Check if any column ends with .AF, and if so rename the whole column name to AF
-    # throw error if there are multiple columns ending with .AF
-    af_cols = [col for col in df.columns if col.endswith(".AF")]
-    if len(af_cols) > 1:
-        raise ValueError(f"Multiple columns ending with .AF: {af_cols}")
-    elif len(af_cols) == 1:
-        df = df.rename(columns={af_cols[0]: "AF"})
+    # Check if any column ends with .AD, and if so rename the whole column name to AD
+    # throw error if there are multiple columns ending with .AD
+    ad_cols = [col for col in df.columns if col.endswith(".AD")]
+    if len(ad_cols) > 1:
+        raise ValueError(f"Multiple columns ending with .AD: {ad_cols}")
+    elif len(ad_cols) == 1:
+        df = df.rename(columns={ad_cols[0]: "AD"})
+
+    return df
+
+
+def calculate_allele_frequency(df):
+    """
+    Calculate allele frequency column from allele depths column
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input dataframe
+
+    Returns
+    -------
+    pandas.DataFrame
+        dataframe with calculated AF column
+    """
+    if not (df["AD"].str.count(",") == 1).all():
+        raise ValueError(
+            "Error: One or more entries in allele depths column (AD) don't contain the expected number of fields (2)."
+        )
+
+    # split into ref and alt counts
+    df[["ref_count", "alt_count"]] = df["AD"].str.split(",", expand=True).astype(int)
+
+    # do AF calculation ourselves
+    df["AF"] = df["alt_count"] / (df["ref_count"] + df["alt_count"])
+    df["AF"] = df["AF"].round(3)
+    df.drop(columns=["ref_count", "alt_count", "AD"], inplace=True)
 
     return df
 
@@ -121,7 +151,10 @@ def main(args):
     )
     df_merged_eff_parsed = parse_eff_field(df_merged)
     df_merged_eff_parsed_renamed = rename_columns(df_merged_eff_parsed, rename_dict)
-    df_final = df_merged_eff_parsed_renamed.fillna("-").replace("", "-")
+    df_merged_eff_parsed_renamed_withAF = calculate_allele_frequency(
+        df_merged_eff_parsed_renamed
+    )
+    df_final = df_merged_eff_parsed_renamed_withAF.fillna("-").replace("", "-")
     df_final.to_csv(args.output, sep="\t", index=False)
 
 


### PR DESCRIPTION
Calculate AF separately for reporting.

Note: marking variants as "filtered" based on AF<0.8 happens before, in juno-mapping based on the VCF file. These AF values might differ slightly, so if a variant is around the 0.8 AF threshold they may appear to be filtered wrongly